### PR TITLE
Reserve some memory for the serializer

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -58,9 +58,14 @@ pub struct Serializer {
     buf: Vec<u8>,
 }
 
+/// Number of bytes reserved by default for the output JSON
+static INITIAL_CAPACITY: usize = 1024;
+
 impl Serializer {
     fn new() -> Self {
-        Serializer { buf: Vec::new() }
+        Serializer {
+            buf: Vec::with_capacity(INITIAL_CAPACITY),
+        }
     }
 }
 


### PR DESCRIPTION
This gives us a nice little gas reduction between 3% and 10%:

```
---- instance::singlepass_test::contract_deducts_gas_handle stdout ----
handle used: 61080
thread 'instance::singlepass_test::contract_deducts_gas_handle' panicked at 'assertion failed: `(left == right)`
  left: `61080`,
 right: `63367`', packages/vm/src/instance.rs:420:9

---- instance::singlepass_test::contract_deducts_gas_init stdout ----
init used: 42753
thread 'instance::singlepass_test::contract_deducts_gas_init' panicked at 'assertion failed: `(left == right)`
  left: `42753`,
 right: `45607`', packages/vm/src/instance.rs:396:9

---- instance::singlepass_test::query_works_with_metering stdout ----
query used: 21097
thread 'instance::singlepass_test::query_works_with_metering' panicked at 'assertion failed: `(left == right)`
  left: `21097`,
 right: `23018`', packages/vm/src/instance.rs:455:9
```