### PR TITLE
solve a warning about unnecessary trailing semicolon

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -865,7 +865,7 @@ mod tests {
     #[test]
     fn struct_empty() {
         #[derive(Debug, Deserialize, PartialEq)]
-        struct Empty {};
+        struct Empty {}
 
         assert_eq!(from_str(r#"{}"#), Ok(Empty {}));
         assert_eq!(serde_json::from_str::<Empty>(r#"{}"#).unwrap(), Empty {});


### PR DESCRIPTION
solve the following warning.

```
warning: unnecessary trailing semicolon
   --> src/de/mod.rs:868:24
    |
868 |         struct Empty {};
    |                        ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolons)]` on by default

warning: `serde-json-wasm` (lib test) generated 1 warning
```

versions:

```
$ rustc --version
rustc 1.48.0-dev

$ cargo --version
cargo 1.58.0-nightly (2e2a16e98 2021-11-08)
```