### PR TITLE
Add support for `ser.str_collect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `str_collect` serialization.
+
+
 ## [0.5.0] - 2022-12-06
 
 ### Added

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -429,11 +429,11 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_struct(name, len)
     }
 
-    fn collect_str<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
+    fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok>
     where
         T: fmt::Display,
     {
-        unreachable!()
+        self.serialize_str(&value.to_string())
     }
 }
 


### PR DESCRIPTION
I am currently working on an on-chain version management issue and wanted to store [semver](https://crates.io/crates/semver) version requirements in my contracts. 

Semver uses `ser.str_collect` for some of its values which is currently not supported (`unreachable!()`).