### PR TITLE
Fix: remove formatting in serde custom error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Removed custom serde error formatting to avoid float inclusion. ([#42])
+
+[#42]: https://github.com/CosmWasm/serde-json-wasm/issues/42
+
 ## [0.5.0] - 2022-12-06
 
 ### Added

--- a/src/de/errors.rs
+++ b/src/de/errors.rs
@@ -68,8 +68,8 @@ pub enum Error {
     /// JSON has a comma after the last value in an array or map.
     TrailingComma,
 
-    /// Custom error message from serde
-    Custom(String),
+    /// Custom error message from serde that should be discarded to avoid floats
+    Custom,
 }
 
 impl error::Error for Error {
@@ -83,11 +83,11 @@ impl error::Error for Error {
 }
 
 impl de::Error for Error {
-    fn custom<T>(msg: T) -> Self
+    fn custom<T>(_msg: T) -> Self
     where
         T: fmt::Display,
     {
-        Error::Custom(msg.to_string())
+        Error::Custom
     }
 }
 
@@ -132,7 +132,7 @@ impl fmt::Display for Error {
                      value."
                 }
                 Error::TrailingComma => "JSON has a comma after the last value in an array or map.",
-                Error::Custom(msg) => msg,
+                Error::Custom => "Custom error from serde was discarded to avoid float inclusion",
             }
         )
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -991,7 +991,7 @@ mod tests {
 
         // wrong number of args
         match from_str::<Xy>(r#"[10]"#) {
-            Err(super::Error::Custom(_)) => {}
+            Err(super::Error::Custom) => {}
             _ => panic!("expect custom error"),
         }
         assert_eq!(


### PR DESCRIPTION
Please see #42 

This has solved a lot of float inclusion issues for me, it'd be great to get it merged upstream. 