### PR TITLE
ser: don’t unnecessarily allocate a String when serialising a character

### DIFF
--- a/src/ser/map.rs
+++ b/src/ser/map.rs
@@ -166,7 +166,8 @@ impl<'a> ser::Serializer for MapKeySerializer<'a> {
     }
 
     fn serialize_char(self, value: char) -> Result<()> {
-        self.ser.serialize_str(&value.to_string())
+        let mut buf = [0u8; 4];
+        self.ser.serialize_str(value.encode_utf8(&mut buf))
     }
 
     fn serialize_bytes(self, _value: &[u8]) -> Result<()> {


### PR DESCRIPTION
Use on-stack buffer to encode a character rather than allocating a new
String.  It’s faster and more memory-efficient.
