### PR TITLE
deserialize_bytes and deserialize_byte_buf support

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -444,21 +444,20 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
     }
 
-    /// Unsupported
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
+        where
+            V: Visitor<'de>,
     {
         self.index = self.slice.len();
-        visitor.visit_bytes(&self.slice)
+        visitor.visit_bytes(self.slice)
     }
 
-    /// Unsupported
-    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: Visitor<'de>,
     {
-        unreachable!()
+        self.index = self.slice.len();
+        visitor.visit_byte_buf(self.slice.to_vec())
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -449,7 +449,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bytes(&self.slice[self.index..])
+        self.index = self.slice.len();
+        visitor.visit_bytes(&self.slice)
     }
 
     /// Unsupported

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -445,11 +445,11 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 
     /// Unsupported
-    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        visitor.visit_bytes(&self.slice[self.index..])
     }
 
     /// Unsupported


### PR DESCRIPTION
I would like to be able to use my own deserializer to parse the raw bytes in my own project. This would allow me to do things like being able to deserialize untagged enums without needing to use serde_cw_value which increases my wasm size by about 200kb :/  ....
Here's an example where I am able to deserialize an untagged enum by trial and error since I have access to the raw bytes.

https://github.com/eqoty-labs/snip721-migratable/blob/0fc9028f497d2e5393d55209b9a49d24cea8d15a/contracts/snip721-migratable/src/msg_untagged_deserializer.rs

There very could be a better way to do this, but this is the best solution I have come up so far.

Plus giving people the ability to write custom deserializers with access to the raw bytes opens the door for other message serialization formats other than json.